### PR TITLE
Fix GetLastError not being called

### DIFF
--- a/src/main/win/WinDisplay.cpp
+++ b/src/main/win/WinDisplay.cpp
@@ -117,7 +117,7 @@ namespace lsp
 
                 if (!(hWindowClass = RegisterClassW(&wc)))
                 {
-                    lsp_error("Error registering window class: %ld", long(GetLastError));
+                    lsp_error("Error registering window class: %ld", long(GetLastError()));
                     return STATUS_UNKNOWN_ERR;
                 }
 
@@ -130,7 +130,7 @@ namespace lsp
 
                 if (!(hClipClass = RegisterClassW(&wc)))
                 {
-                    lsp_error("Error registering clipboard window class: %ld", long(GetLastError));
+                    lsp_error("Error registering clipboard window class: %ld", long(GetLastError()));
                     return STATUS_UNKNOWN_ERR;
                 }
 


### PR DESCRIPTION
This PR fixes a compile error that happened on Windows due to `GetLastError` not being called but instead just passed as a function. In all other occurrences in the file were `GetLastError()` (with parentheses), only these two were without them.