### PR TITLE
Fix endless vertical flipping on macOS

### DIFF
--- a/src/main/cocoa/CocoaCairoSurface.mm
+++ b/src/main/cocoa/CocoaCairoSurface.mm
@@ -374,6 +374,7 @@ namespace lsp
                 }
 
                 // Initialize settings
+                ::cairo_identity_matrix(pCR);
                 ::cairo_set_antialias(pCR, CAIRO_ANTIALIAS_FAST);
                 ::cairo_set_line_join(pCR, CAIRO_LINE_JOIN_BEVEL);
                 ::cairo_set_tolerance(pCR, 0.5);


### PR DESCRIPTION
Since we are performing a transform, we first need to ensure the CTM is reset to identity, otherwise the flips stack on every frame.