### PR TITLE
fix(cocoa): make VST3 hosted UI render and route input correctly 

### DIFF
--- a/include/private/cocoa/CocoaCairoView.h
+++ b/include/private/cocoa/CocoaCairoView.h
@@ -31,10 +31,13 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface CocoaCairoView : NSView 
+@class LSPRedrawTimerProxy;
+
+@interface CocoaCairoView : NSView
 
     @property (assign) cairo_surface_t *imageSurface;
     @property (strong) NSTimer *redrawTimer;
+    @property (strong) LSPRedrawTimerProxy *redrawTimerProxy;
     @property (strong) NSCursor *nextCursor;
     @property (assign) bool needsRedrawing;
     @property (nonatomic, assign) lsp::ws::cocoa::CocoaDisplay *display;

--- a/include/private/cocoa/CocoaCairoView.h
+++ b/include/private/cocoa/CocoaCairoView.h
@@ -31,24 +31,17 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class LSPRedrawTimerProxy;
-
 @interface CocoaCairoView : NSView
 
     @property (assign) cairo_surface_t *imageSurface;
-    @property (strong) NSTimer *redrawTimer;
-    @property (strong) LSPRedrawTimerProxy *redrawTimerProxy;
     @property (strong) NSCursor *nextCursor;
     @property (assign) bool needsRedrawing;
     @property (nonatomic, assign) lsp::ws::cocoa::CocoaDisplay *display;
     @property (assign) NSTrackingArea *trackingArea;
 
     - (CGImageRef)renderCairoImage;
-    - (void)triggerRedraw;
     - (void)setCursor:(NSCursor *)cursor;
     - (void)setImage:(cairo_surface_t *)image;
-    - (void)startRedrawLoop;
-    - (void)stopRedrawLoop;
     - (void)updateFrame:(NSRect)frameRect;
 @end
 

--- a/include/private/cocoa/CocoaDisplay.h
+++ b/include/private/cocoa/CocoaDisplay.h
@@ -62,6 +62,8 @@ namespace lsp
                     lltl::parray<CocoaWindow>   vWindows;                   // All registered windows
                     lltl::parray<CocoaWindow>   vGrab[__GRAB_TOTAL];        // Windows currently grabbing events, per group
                     void                       *pGrabMonitor;               // NSEvent local monitor token (id), nil when no grabs
+                    void                       *pIterationTimer;            // NSTimer * driving do_main_iteration in hosted mode
+                    void                       *pIterationTimerProxy;       // LSPDisplayTimerProxy * (target proxy with raw back-pointer)
                     size_t                      lastMouseButton;
                     CocoaWindow                *pDragTarget;     // window that received mouseDown until matching mouseUp
                 
@@ -81,6 +83,11 @@ namespace lsp
                     // includable from C++ translation units.
                     bool                        dispatch_grabbed_event(void *event);
                     CocoaWindow                *find_topmost_grab_window();
+
+                public:
+                    // Called from the NSRunLoop-scheduled 60 Hz iteration timer.
+                    // Public so the Objective-C proxy can invoke it.
+                    void                        tick_redraw();
                 
                 public:
                     // Main loop management

--- a/include/private/cocoa/CocoaDisplay.h
+++ b/include/private/cocoa/CocoaDisplay.h
@@ -61,6 +61,7 @@ namespace lsp
                     lltl::parray<CocoaWindow>   sTargets;                   // Targets for event delivery
                     lltl::parray<CocoaWindow>   vWindows;                   // All registered windows
                     size_t                      lastMouseButton;
+                    CocoaWindow                *pDragTarget;     // window that received mouseDown until matching mouseUp
                 
                 #ifdef USE_LIBFREETYPE
                     ft::FontManager             sFontManager;

--- a/include/private/cocoa/CocoaDisplay.h
+++ b/include/private/cocoa/CocoaDisplay.h
@@ -60,6 +60,8 @@ namespace lsp
                     volatile timestamp_t        nLastIdleCall;              // The time of last idle call
                     lltl::parray<CocoaWindow>   sTargets;                   // Targets for event delivery
                     lltl::parray<CocoaWindow>   vWindows;                   // All registered windows
+                    lltl::parray<CocoaWindow>   vGrab[__GRAB_TOTAL];        // Windows currently grabbing events, per group
+                    void                       *pGrabMonitor;               // NSEvent local monitor token (id), nil when no grabs
                     size_t                      lastMouseButton;
                     CocoaWindow                *pDragTarget;     // window that received mouseDown until matching mouseUp
                 
@@ -73,6 +75,12 @@ namespace lsp
                     void                        get_enviroment_frame_sizes();
                     status_t                    do_main_iteration(timestamp_t ts);
                     CocoaWindow                *find_window(const nswindow_t & wnd);
+                    void                        install_grab_monitor();
+                    void                        uninstall_grab_monitor();
+                    // event is an NSEvent*; void* keeps the header
+                    // includable from C++ translation units.
+                    bool                        dispatch_grabbed_event(void *event);
+                    CocoaWindow                *find_topmost_grab_window();
                 
                 public:
                     // Main loop management
@@ -92,6 +100,11 @@ namespace lsp
                     virtual IWindow            *create_window() override;
                     virtual IWindow            *create_window(size_t screen) override;
                     virtual IWindow            *create_window(void *handle) override;
+
+                    // Grab management (used by popup widgets to close on outside-click)
+                    status_t                    grab_events(CocoaWindow *wnd, grab_t group);
+                    status_t                    ungrab_events(CocoaWindow *wnd);
+                    bool                        is_grabbing_events(const CocoaWindow *wnd) const;
 
                     // Monitor management
                     virtual const MonitorInfo  *enum_monitors(size_t *count) override;

--- a/include/private/cocoa/CocoaWindow.h
+++ b/include/private/cocoa/CocoaWindow.h
@@ -53,6 +53,7 @@ namespace lsp
                 private:
                     friend class CocoaDisplay;
                     NSWindow            *pCocoaWindow;
+                    NSView              *pCocoaParentView;              // Host's NSView slot when bWrapper=true
                     CocoaCairoView      *pCocoaView;                    // The View of the window
                     NSCursor            *pCocoaCursor;                  // The Cursor of the View
                     NSWindow            *transientParent;
@@ -134,6 +135,7 @@ namespace lsp
 
                     virtual status_t    handle_event(const event_t *ev) override;
                     virtual ISurface   *get_surface() override;
+                    virtual status_t    set_parent(void *parent) override;
 
                     virtual status_t    invalidate() override;
 

--- a/include/private/cocoa/CocoaWindow.h
+++ b/include/private/cocoa/CocoaWindow.h
@@ -151,6 +151,10 @@ namespace lsp
                     virtual void       *handle() override;
                     NSWindow           *get_window_handler();
 
+                    virtual status_t    grab_events(grab_t group) override;
+                    virtual status_t    ungrab_events() override;
+                    virtual bool        is_grabbing_events() const override;
+
             };
         } /* namespace cocoa */
     } /* namespace ws */

--- a/src/main/cocoa/CocoaCairoView.mm
+++ b/src/main/cocoa/CocoaCairoView.mm
@@ -183,6 +183,8 @@
 // Updates the view
 - (void)triggerRedraw
 {
+    if (self.display != NULL)
+        self.display->main_iteration();
     if (self->_needsRedrawing)
         [self setNeedsDisplay:YES];
 }

--- a/src/main/cocoa/CocoaCairoView.mm
+++ b/src/main/cocoa/CocoaCairoView.mm
@@ -34,47 +34,6 @@
 #include <cairo.h>
 #include <cairo-quartz.h>
 
-// Forward-target for the redraw NSTimer. NSTimer retains its target, which
-// produces a retain cycle with CocoaCairoView (view -> timer -> view) so the
-// view's -dealloc never runs and stopRedrawLoop is never called. When the
-// hosting CocoaDisplay/window is torn down before the timer is invalidated
-// (e.g. a still-open popup CocoaWindow whose CocoaWindow::destroy() is not
-// invoked by the framework), the next timer tick dereferences a dangling
-// CocoaDisplay* and crashes in -[CocoaCairoView triggerRedraw].
-//
-// The proxy holds the view as a raw, non-retaining pointer. -invalidate is
-// called from the view's -dealloc to clear the back-pointer before the view
-// is freed; the proxy itself outlives the view long enough for the run loop
-// to release the timer.
-@interface LSPRedrawTimerProxy : NSObject {
-    CocoaCairoView *_view;
-}
-- (instancetype)initWithView:(CocoaCairoView *)view;
-- (void)invalidate;
-- (void)tick:(NSTimer *)timer;
-@end
-
-@implementation LSPRedrawTimerProxy
-- (instancetype)initWithView:(CocoaCairoView *)view
-{
-    self = [super init];
-    if (self)
-        _view = view;
-    return self;
-}
-- (void)invalidate
-{
-    _view = nil;
-}
-- (void)tick:(NSTimer *)timer
-{
-    // _view is a raw pointer; safe because -invalidate is called from the
-    // view's -dealloc, which can only run once the timer no longer retains it.
-    if (_view != nil)
-        [_view triggerRedraw];
-}
-@end
-
 @implementation CocoaCairoView
 
 // We need an overloaded objective c - NSView Class for Rendering, drawRect is triggered on create/update
@@ -182,43 +141,9 @@
     return image;
 }
 
-// Starts the redraw loop
-- (void)startRedrawLoop
-{
-    if (self->_redrawTimer == nil)
-    {
-        // Route the timer through a tiny proxy whose -tick: forwards to this
-        // view via a raw pointer. This avoids the NSTimer/view retain cycle —
-        // see LSPRedrawTimerProxy comment at the top of this file.
-        self->_redrawTimerProxy = [[LSPRedrawTimerProxy alloc] initWithView:self];
-        self->_redrawTimer = [NSTimer   scheduledTimerWithTimeInterval:(1.0/60.0)
-                                        target:self->_redrawTimerProxy
-                                        selector:@selector(tick:)
-                                        userInfo:nil
-                                        repeats:YES];
-    }
-}
-
-// Stops the redraw loop
-- (void)stopRedrawLoop
-{
-    if (self->_redrawTimer != nil)
-    {
-        [self->_redrawTimer invalidate];
-        self->_redrawTimer = nil;
-    }
-    if (self->_redrawTimerProxy != nil)
-    {
-        [self->_redrawTimerProxy invalidate];
-        [self->_redrawTimerProxy release];
-        self->_redrawTimerProxy = nil;
-    }
-}
-
 // Destructor
 - (void)dealloc
 {
-    [self stopRedrawLoop];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 
     if (self.trackingArea)
@@ -228,15 +153,6 @@
     }
     self.display = nullptr;
     [super dealloc];
-}
-
-// Updates the view
-- (void)triggerRedraw
-{
-    if (self.display != NULL)
-        self.display->main_iteration();
-    if (self->_needsRedrawing)
-        [self setNeedsDisplay:YES];
 }
 
 // Sets the cairo image

--- a/src/main/cocoa/CocoaCairoView.mm
+++ b/src/main/cocoa/CocoaCairoView.mm
@@ -34,6 +34,47 @@
 #include <cairo.h>
 #include <cairo-quartz.h>
 
+// Forward-target for the redraw NSTimer. NSTimer retains its target, which
+// produces a retain cycle with CocoaCairoView (view -> timer -> view) so the
+// view's -dealloc never runs and stopRedrawLoop is never called. When the
+// hosting CocoaDisplay/window is torn down before the timer is invalidated
+// (e.g. a still-open popup CocoaWindow whose CocoaWindow::destroy() is not
+// invoked by the framework), the next timer tick dereferences a dangling
+// CocoaDisplay* and crashes in -[CocoaCairoView triggerRedraw].
+//
+// The proxy holds the view as a raw, non-retaining pointer. -invalidate is
+// called from the view's -dealloc to clear the back-pointer before the view
+// is freed; the proxy itself outlives the view long enough for the run loop
+// to release the timer.
+@interface LSPRedrawTimerProxy : NSObject {
+    CocoaCairoView *_view;
+}
+- (instancetype)initWithView:(CocoaCairoView *)view;
+- (void)invalidate;
+- (void)tick:(NSTimer *)timer;
+@end
+
+@implementation LSPRedrawTimerProxy
+- (instancetype)initWithView:(CocoaCairoView *)view
+{
+    self = [super init];
+    if (self)
+        _view = view;
+    return self;
+}
+- (void)invalidate
+{
+    _view = nil;
+}
+- (void)tick:(NSTimer *)timer
+{
+    // _view is a raw pointer; safe because -invalidate is called from the
+    // view's -dealloc, which can only run once the timer no longer retains it.
+    if (_view != nil)
+        [_view triggerRedraw];
+}
+@end
+
 @implementation CocoaCairoView
 
 // We need an overloaded objective c - NSView Class for Rendering, drawRect is triggered on create/update
@@ -146,9 +187,13 @@
 {
     if (self->_redrawTimer == nil)
     {
+        // Route the timer through a tiny proxy whose -tick: forwards to this
+        // view via a raw pointer. This avoids the NSTimer/view retain cycle —
+        // see LSPRedrawTimerProxy comment at the top of this file.
+        self->_redrawTimerProxy = [[LSPRedrawTimerProxy alloc] initWithView:self];
         self->_redrawTimer = [NSTimer   scheduledTimerWithTimeInterval:(1.0/60.0)
-                                        target:self
-                                        selector:@selector(triggerRedraw)
+                                        target:self->_redrawTimerProxy
+                                        selector:@selector(tick:)
                                         userInfo:nil
                                         repeats:YES];
     }
@@ -159,10 +204,15 @@
 {
     if (self->_redrawTimer != nil)
     {
-        [self->_redrawTimer invalidate]; 
+        [self->_redrawTimer invalidate];
         self->_redrawTimer = nil;
     }
-
+    if (self->_redrawTimerProxy != nil)
+    {
+        [self->_redrawTimerProxy invalidate];
+        [self->_redrawTimerProxy release];
+        self->_redrawTimerProxy = nil;
+    }
 }
 
 // Destructor

--- a/src/main/cocoa/CocoaCairoView.mm
+++ b/src/main/cocoa/CocoaCairoView.mm
@@ -94,6 +94,8 @@
     self = [super initWithFrame:frameRect];
     if (self)
     {
+        [self setWantsLayer:YES];
+        self.layer.backgroundColor = [[NSColor blackColor] CGColor];
         //lsp_trace("Register event for view: %p", self);
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
         [center addObserverForName:@"ForceExpose"
@@ -240,6 +242,16 @@
         return YES;
     }
     return NO;
+}
+
+- (BOOL)acceptsFirstResponder
+{
+    return YES;
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent *)event
+{
+    return YES;
 }
 
 - (void)updateTrackingAreas

--- a/src/main/cocoa/CocoaDisplay.mm
+++ b/src/main/cocoa/CocoaDisplay.mm
@@ -55,6 +55,8 @@ namespace lsp
             CocoaDisplay::CocoaDisplay(): IDisplay()
             {
                bExit                   = false;
+               lastMouseButton         = 0;
+               pDragTarget             = NULL;
             }
 
             CocoaDisplay::~CocoaDisplay()
@@ -207,12 +209,53 @@ namespace lsp
                     return;
 
                 NSEventType type = [nsevent type];
+
+                // During an in-progress drag, route mouse events to the window that received
+                // the matching mouseDown — even if the cursor leaves the view's bounds.
+                const bool isDragMove = (type == NSEventTypeLeftMouseDragged) ||
+                                        (type == NSEventTypeRightMouseDragged) ||
+                                        (type == NSEventTypeOtherMouseDragged) ||
+                                        (type == NSEventTypeMouseMoved);
+                const bool isMouseUp  = (type == NSEventTypeLeftMouseUp) ||
+                                        (type == NSEventTypeRightMouseUp) ||
+                                        (type == NSEventTypeOtherMouseUp);
+
+                CocoaWindow *target = NULL;
+                if ((isDragMove || isMouseUp) && pDragTarget != NULL)
+                    target = pDragTarget;
+
                 const nswindow_t nsWindow = nswindow_t { [nsevent window] };
-                CocoaWindow *target = find_window(nsWindow);
+                if (!target)
+                    target = find_window(nsWindow);
+
+                // Embedded case: the NSEvent's window is the host's (e.g. Ableton's), not ours.
+                // Locate our CocoaWindow by walking up from the hit-test view to a known pCocoaView.
+                if (!target)
+                {
+                    NSView *root = [nsWindow.window contentView];
+                    NSPoint p = [nsevent locationInWindow];
+                    NSView *hit = [root hitTest:p];
+                    for (size_t i = 0, n = vWindows.size(); i < n && !target; ++i)
+                    {
+                        CocoaWindow *w = vWindows.uget(i);
+                        if (!w || !w->pCocoaView)
+                            continue;
+                        NSView *v = hit;
+                        while (v != nil)
+                        {
+                            if (v == w->pCocoaView)
+                            {
+                                target = w;
+                                break;
+                            }
+                            v = [v superview];
+                        }
+                    }
+                }
 
                 if (!target)
                     return;
-                
+
                 event_t ue = {};
                 init_event(&ue);
                 ue.nTime = timestamp_t([nsevent timestamp] * 1000);
@@ -222,9 +265,31 @@ namespace lsp
                 unichar keysym = 0;
 
                 NSPoint locInWindow = [nsevent locationInWindow];
-                NSView *targetView = [[nsWindow.window contentView] hitTest:locInWindow];
-                NSPoint locInView = [targetView convertPoint:locInWindow fromView:nil];
-                NSRect cFrame = [targetView frame];
+                // Resolve event coordinates against the target view directly so they stay valid
+                // when the cursor leaves the view (during a drag).
+                NSView *coordView = target->pCocoaView;
+                NSPoint locInView;
+                NSRect cFrame;
+                if (coordView != nil && [coordView window] != nil)
+                {
+                    if ([coordView window] != nsWindow.window)
+                    {
+                        NSPoint scr = [nsWindow.window convertPointToScreen:locInWindow];
+                        NSPoint inHostWnd = [[coordView window] convertPointFromScreen:scr];
+                        locInView = [coordView convertPoint:inHostWnd fromView:nil];
+                    }
+                    else
+                    {
+                        locInView = [coordView convertPoint:locInWindow fromView:nil];
+                    }
+                    cFrame = [coordView frame];
+                }
+                else
+                {
+                    NSView *hitView = [[nsWindow.window contentView] hitTest:locInWindow];
+                    locInView = [hitView convertPoint:locInWindow fromView:nil];
+                    cFrame = [hitView frame];
+                }
 
                 ue.nLeft = locInView.x;
                 ue.nTop = cFrame.size.height - locInView.y;
@@ -238,6 +303,7 @@ namespace lsp
                         ue.nType = UIE_MOUSE_DOWN;
                         ue.nCode = decode_mcb(nsevent);
                         lastMouseButton = decode_modifier(nsevent);
+                        pDragTarget = target;
                         //ue.nState = decode_modifier(nsevent);
                         break;
 
@@ -249,6 +315,7 @@ namespace lsp
                         ue.nState = decode_modifier(nsevent);
                         ue.nState = lastMouseButton;
                         lastMouseButton = decode_modifier(nsevent);
+                        pDragTarget = NULL;
                         break;
 
                     case NSEventTypeMouseMoved:

--- a/src/main/cocoa/CocoaDisplay.mm
+++ b/src/main/cocoa/CocoaDisplay.mm
@@ -44,7 +44,42 @@
 
 #include <private/cocoa/CocoaDisplay.h>
 #include <private/cocoa/CocoaWindow.h>
+#include <private/cocoa/CocoaCairoView.h>
 #include <private/cocoa/defs.h>
+
+// Forward-target for the 60 Hz redraw NSTimer that drives
+// CocoaDisplay::do_main_iteration in hosted mode. Same shape as
+// LSPRedrawTimerProxy in CocoaCairoView.mm: NSTimer retains its target,
+// so we keep the back-pointer raw and let the C++ destroy() clear it
+// before the display is freed. Block-based NSTimer was rejected because
+// the captured block could outlive the C++ destroy() call when the run
+// loop released the timer asynchronously.
+@interface LSPDisplayTimerProxy : NSObject {
+    lsp::ws::cocoa::CocoaDisplay *_display;
+}
+- (instancetype)initWithDisplay:(lsp::ws::cocoa::CocoaDisplay *)display;
+- (void)invalidate;
+- (void)tick:(NSTimer *)timer;
+@end
+
+@implementation LSPDisplayTimerProxy
+- (instancetype)initWithDisplay:(lsp::ws::cocoa::CocoaDisplay *)display
+{
+    self = [super init];
+    if (self)
+        _display = display;
+    return self;
+}
+- (void)invalidate
+{
+    _display = NULL;
+}
+- (void)tick:(NSTimer *)timer
+{
+    if (_display != NULL)
+        _display->tick_redraw();
+}
+@end
 
 namespace lsp
 {
@@ -58,6 +93,8 @@ namespace lsp
                lastMouseButton         = 0;
                pDragTarget             = NULL;
                pGrabMonitor            = NULL;
+               pIterationTimer         = NULL;
+               pIterationTimerProxy    = NULL;
             }
 
             CocoaDisplay::~CocoaDisplay()
@@ -92,7 +129,39 @@ namespace lsp
                 if (pEstimation == NULL)
                     return STATUS_NO_MEM;
 
+                // In hosted mode (plugin) NSApp is owned by the host. Install
+                // a single 60 Hz NSTimer into the host's NSRunLoop that drives
+                // do_main_iteration() for every registered window.
+                // In standalone mode CocoaDisplay::main() runs its own loop, so
+                // no timer is needed.
+                if (!standaloneApp)
+                {
+                    LSPDisplayTimerProxy *proxy = [[LSPDisplayTimerProxy alloc] initWithDisplay:this];
+                    NSTimer *timer = [NSTimer scheduledTimerWithTimeInterval:(1.0/60.0)
+                                              target:proxy
+                                              selector:@selector(tick:)
+                                              userInfo:nil
+                                              repeats:YES];
+                    pIterationTimer      = (void *) timer;   // owned by run loop
+                    pIterationTimerProxy = (void *) proxy;   // owned by us
+                }
+
                 return IDisplay::init(argc, argv);
+            }
+
+            void CocoaDisplay::tick_redraw()
+            {
+                @autoreleasepool {
+                    do_main_iteration(system::get_time_millis());
+                    for (size_t i = 0, n = vWindows.size(); i < n; ++i)
+                    {
+                        CocoaWindow * const wnd = vWindows.uget(i);
+                        if (wnd == NULL || wnd->pCocoaView == nil)
+                            continue;
+                        if (wnd->pCocoaView.needsRedrawing)
+                            [wnd->pCocoaView setNeedsDisplay:YES];
+                    }
+                }
             }
 
             status_t CocoaDisplay::main()
@@ -677,26 +746,26 @@ namespace lsp
 
             void CocoaDisplay::destroy()
             {
+                // Stop the display-wide iteration timer first so no tick can
+                // fire into a half-destroyed display.
+                if (pIterationTimer != NULL)
+                {
+                    [(NSTimer *) pIterationTimer invalidate];
+                    pIterationTimer = NULL;
+                }
+                if (pIterationTimerProxy != NULL)
+                {
+                    LSPDisplayTimerProxy *proxy = (LSPDisplayTimerProxy *) pIterationTimerProxy;
+                    [proxy invalidate];
+                    [proxy release];
+                    pIterationTimerProxy = NULL;
+                }
+
                 // Tear down any installed grab monitor so it cannot fire into
                 // freed state if grabs were active at shutdown.
                 uninstall_grab_monitor();
                 for (size_t i = 0; i < __GRAB_TOTAL; ++i)
                     vGrab[i].clear();
-
-                // Stop any redraw timers and clear back-pointers on views of
-                // windows that the framework didn't explicitly destroy() (most
-                // commonly popups whose CocoaWindow stays alive until the
-                // hosting plug-in releases its widget tree). Otherwise their
-                // NSTimer keeps firing after this CocoaDisplay is freed and
-                // segfaults with a dangling display pointer.
-                for (size_t i = 0, n = vWindows.size(); i < n; ++i)
-                {
-                    CocoaWindow * const wnd = vWindows.uget(i);
-                    if (wnd == NULL || wnd->pCocoaView == nil)
-                        continue;
-                    [wnd->pCocoaView stopRedrawLoop];
-                    [wnd->pCocoaView setDisplay:NULL];
-                }
 
                 // Destroy font manager
             #ifdef USE_LIBFREETYPE

--- a/src/main/cocoa/CocoaDisplay.mm
+++ b/src/main/cocoa/CocoaDisplay.mm
@@ -504,6 +504,21 @@ namespace lsp
 
             void CocoaDisplay::destroy()
             {
+                // Stop any redraw timers and clear back-pointers on views of
+                // windows that the framework didn't explicitly destroy() (most
+                // commonly popups whose CocoaWindow stays alive until the
+                // hosting plug-in releases its widget tree). Otherwise their
+                // NSTimer keeps firing after this CocoaDisplay is freed and
+                // segfaults with a dangling display pointer.
+                for (size_t i = 0, n = vWindows.size(); i < n; ++i)
+                {
+                    CocoaWindow * const wnd = vWindows.uget(i);
+                    if (wnd == NULL || wnd->pCocoaView == nil)
+                        continue;
+                    [wnd->pCocoaView stopRedrawLoop];
+                    [wnd->pCocoaView setDisplay:NULL];
+                }
+
                 // Destroy font manager
             #ifdef USE_LIBFREETYPE
                 sFontManager.destroy();

--- a/src/main/cocoa/CocoaDisplay.mm
+++ b/src/main/cocoa/CocoaDisplay.mm
@@ -57,6 +57,7 @@ namespace lsp
                bExit                   = false;
                lastMouseButton         = 0;
                pDragTarget             = NULL;
+               pGrabMonitor            = NULL;
             }
 
             CocoaDisplay::~CocoaDisplay()
@@ -486,7 +487,7 @@ namespace lsp
             CocoaWindow *CocoaDisplay::find_window(const nswindow_t & wnd)
             {
                 const NSWindow * const nswnd = wnd.window;
-                
+
                 size_t n = vWindows.size();
 
                 for (size_t i = 0; i < n; ++i)
@@ -501,9 +502,187 @@ namespace lsp
                 return NULL;
             }
 
+            CocoaWindow *CocoaDisplay::find_topmost_grab_window()
+            {
+                // Highest priority group with at least one window wins.
+                for (ssize_t g = __GRAB_TOTAL - 1; g >= 0; --g)
+                {
+                    lltl::parray<CocoaWindow> &arr = vGrab[g];
+                    const size_t n = arr.size();
+                    if (n == 0)
+                        continue;
+                    // Most recently added in this group is the topmost popup
+                    // (matches widget framework expectations on Linux/Win).
+                    return arr.uget(n - 1);
+                }
+                return NULL;
+            }
+
+            static bool point_inside_window(NSPoint screenPt, CocoaWindow *wnd)
+            {
+                if (wnd == NULL)
+                    return false;
+                NSWindow *nsWin = wnd->get_window_handler();
+                if (nsWin == nil)
+                    return false;
+                NSRect f = [nsWin frame];
+                return NSPointInRect(screenPt, f);
+            }
+
+            bool CocoaDisplay::dispatch_grabbed_event(void *eventPtr)
+            {
+                NSEvent *event = (NSEvent *) eventPtr;
+                CocoaWindow *target = find_topmost_grab_window();
+                if (target == NULL)
+                    return false;
+
+                // Compute screen coords of the click.
+                NSPoint screenPt;
+                if ([event window] != nil)
+                    screenPt = [[event window] convertPointToScreen:[event locationInWindow]];
+                else
+                    screenPt = [event locationInWindow];
+
+                // If the click landed inside any grabbing popup, do nothing
+                // here — AppKit delivers the event to that popup's NSWindow
+                // via the normal route.
+                for (ssize_t g = __GRAB_TOTAL - 1; g >= 0; --g)
+                {
+                    lltl::parray<CocoaWindow> &arr = vGrab[g];
+                    for (size_t i = 0, n = arr.size(); i < n; ++i)
+                    {
+                        if (point_inside_window(screenPt, arr.uget(i)))
+                            return false;
+                    }
+                }
+
+                // Click is outside every grabbing popup. Synthesize a
+                // UIE_MOUSE_DOWN at popup-local coords (which will be outside
+                // the popup's view bounds) and deliver it directly to the
+                // topmost popup so the widget framework's outside-click logic
+                // (e.g. Menu::hide()) fires.
+                NSWindow *tgtWin = target->get_window_handler();
+                NSRect tgtFrame = (tgtWin != nil) ? [tgtWin frame] : NSMakeRect(0,0,0,0);
+                NSPoint local = NSMakePoint(screenPt.x - tgtFrame.origin.x,
+                                            screenPt.y - tgtFrame.origin.y);
+
+                event_t ue;
+                init_event(&ue);
+                ue.nLeft  = ssize_t(local.x);
+                // Convert from Cocoa bottom-origin to top-origin.
+                ue.nTop   = ssize_t(tgtFrame.size.height - local.y);
+                ue.nTime  = timestamp_t([event timestamp] * 1000);
+
+                NSEventType etype = [event type];
+                switch (etype)
+                {
+                    case NSEventTypeLeftMouseDown:
+                    case NSEventTypeRightMouseDown:
+                    case NSEventTypeOtherMouseDown:
+                        ue.nType = UIE_MOUSE_DOWN;
+                        ue.nCode = decode_mcb(event);
+                        break;
+                    case NSEventTypeLeftMouseUp:
+                    case NSEventTypeRightMouseUp:
+                    case NSEventTypeOtherMouseUp:
+                        ue.nType = UIE_MOUSE_UP;
+                        ue.nCode = decode_mcb(event);
+                        break;
+                    default:
+                        return false;
+                }
+
+                target->handle_event(&ue);
+                // Do not consume — the host (DAW) chrome (e.g. window close
+                // button) still needs to receive the original click.
+                return false;
+            }
+
+            void CocoaDisplay::install_grab_monitor()
+            {
+                if (pGrabMonitor != NULL)
+                    return;
+
+                CocoaDisplay *self = this;
+                NSEventMask mask = NSEventMaskLeftMouseDown
+                                 | NSEventMaskRightMouseDown
+                                 | NSEventMaskOtherMouseDown;
+                id token = [NSEvent addLocalMonitorForEventsMatchingMask:mask
+                                    handler:^NSEvent *(NSEvent *evt)
+                                    {
+                                        if (self->dispatch_grabbed_event(evt))
+                                            return nil; // consumed
+                                        return evt;
+                                    }];
+                pGrabMonitor = (void *) [token retain];
+            }
+
+            void CocoaDisplay::uninstall_grab_monitor()
+            {
+                if (pGrabMonitor == NULL)
+                    return;
+                id token = (id) pGrabMonitor;
+                [NSEvent removeMonitor:token];
+                [token release];
+                pGrabMonitor = NULL;
+            }
+
+            status_t CocoaDisplay::grab_events(CocoaWindow *wnd, grab_t group)
+            {
+                if (wnd == NULL || group >= __GRAB_TOTAL)
+                    return STATUS_BAD_ARGUMENTS;
+
+                // Reject duplicate grab for the same window in any group.
+                size_t total = 0;
+                for (size_t i = 0; i < __GRAB_TOTAL; ++i)
+                {
+                    if (vGrab[i].index_of(wnd) >= 0)
+                        return STATUS_DUPLICATED;
+                    total += vGrab[i].size();
+                }
+
+                if (!vGrab[group].add(wnd))
+                    return STATUS_NO_MEM;
+
+                if (total == 0)
+                    install_grab_monitor();
+                return STATUS_OK;
+            }
+
+            status_t CocoaDisplay::ungrab_events(CocoaWindow *wnd)
+            {
+                bool found = false;
+                size_t remaining = 0;
+                for (size_t i = 0; i < __GRAB_TOTAL; ++i)
+                {
+                    if (vGrab[i].premove(wnd))
+                        found = true;
+                    remaining += vGrab[i].size();
+                }
+                if (!found)
+                    return STATUS_NO_GRAB;
+                if (remaining == 0)
+                    uninstall_grab_monitor();
+                return STATUS_OK;
+            }
+
+            bool CocoaDisplay::is_grabbing_events(const CocoaWindow *wnd) const
+            {
+                for (size_t i = 0; i < __GRAB_TOTAL; ++i)
+                    if (vGrab[i].index_of(const_cast<CocoaWindow *>(wnd)) >= 0)
+                        return true;
+                return false;
+            }
+
 
             void CocoaDisplay::destroy()
             {
+                // Tear down any installed grab monitor so it cannot fire into
+                // freed state if grabs were active at shutdown.
+                uninstall_grab_monitor();
+                for (size_t i = 0; i < __GRAB_TOTAL; ++i)
+                    vGrab[i].clear();
+
                 // Stop any redraw timers and clear back-pointers on views of
                 // windows that the framework didn't explicitly destroy() (most
                 // commonly popups whose CocoaWindow stays alive until the

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -68,8 +68,10 @@ namespace lsp
                 enState                 = WS_NORMAL;
 
                 bWrapper                = wrapper;
+                pCocoaParentView        = NULL;
 
                 if (bWrapper) {
+                    pCocoaParentView = view;
                     pCocoaWindow = [view window];
                 }
 
@@ -118,6 +120,7 @@ namespace lsp
                                                 defer:NO];
 
                     pCocoaWindow = window;
+                    [pCocoaWindow setBackgroundColor:[NSColor blackColor]];
                     [pCocoaWindow setIsVisible:NO];
 
                     // Create a cocoa view and set it to window
@@ -137,8 +140,9 @@ namespace lsp
                 }
                 else
                 {
-                    CocoaCairoView *wrapperView = [[CocoaCairoView alloc] initWithFrame:[[pCocoaWindow contentView] bounds]];
-                    [[pCocoaWindow contentView] addSubview:wrapperView positioned:NSWindowAbove relativeTo:nil];
+                    NSView *host = (pCocoaParentView != NULL) ? pCocoaParentView : [pCocoaWindow contentView];
+                    CocoaCairoView *wrapperView = [[CocoaCairoView alloc] initWithFrame:[host bounds]];
+                    [host addSubview:wrapperView positioned:NSWindowAbove relativeTo:nil];
                     wrapperView.display = pCocoaDisplay;
                     pCocoaView = wrapperView;
                     [pCocoaView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
@@ -364,7 +368,41 @@ namespace lsp
                     return STATUS_BAD_STATE;
 
                 bInvalidate = true;
-                
+
+                return STATUS_OK;
+            }
+
+            status_t CocoaWindow::set_parent(void *parent)
+            {
+                NSView *hostView = (__bridge NSView *)parent;
+                if (pCocoaView == nil)
+                    return STATUS_BAD_STATE;
+
+                if (hostView != nil)
+                {
+                    if (pCocoaWindow != nil)
+                        [pCocoaWindow orderOut:nil];
+
+                    if ([pCocoaView superview] != hostView)
+                    {
+                        [pCocoaView retain];
+                        [pCocoaView removeFromSuperview];
+                        [pCocoaView setFrame:[hostView bounds]];
+                        [pCocoaView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+                        [hostView addSubview:pCocoaView positioned:NSWindowAbove relativeTo:nil];
+                        [[hostView window] makeFirstResponder:pCocoaView];
+                        [pCocoaView release];
+                    }
+                    pCocoaParentView = hostView;
+                }
+                else if (pCocoaParentView != nil)
+                {
+                    [pCocoaView removeFromSuperview];
+                    if (pCocoaWindow != nil)
+                        [pCocoaWindow setContentView:pCocoaView];
+                    pCocoaParentView = nil;
+                }
+
                 return STATUS_OK;
             }
 
@@ -804,7 +842,8 @@ namespace lsp
                 }
 
                 //[pCocoaWindow orderFrontRegardless];
-                [pCocoaWindow makeKeyAndOrderFront:nil];
+                if (pCocoaParentView == nil)
+                    [pCocoaWindow makeKeyAndOrderFront:nil];
 
                 // Simulate missing show event
                 lsp_trace("Emitting UIE_SHOW event");
@@ -874,6 +913,23 @@ namespace lsp
             {
                 if (realize == nullptr)
                     return STATUS_BAD_ARGUMENTS;
+
+                if (pCocoaParentView != nil)
+                {
+                    NSWindow *hostWnd = [pCocoaParentView window];
+                    if (hostWnd == nil)
+                        return STATUS_BAD_STATE;
+                    NSRect b = [pCocoaParentView convertRect:[pCocoaParentView bounds] toView:nil];
+                    NSRect s = [hostWnd convertRectToScreen:b];
+                    ssize_t screenW = 0, screenH = 0;
+                    pCocoaDisplay->screen_size(0, &screenW, &screenH);
+                    realize->nLeft   = static_cast<ssize_t>(s.origin.x);
+                    realize->nTop    = static_cast<ssize_t>(screenH - s.origin.y - s.size.height);
+                    realize->nWidth  = static_cast<ssize_t>(s.size.width);
+                    realize->nHeight = static_cast<ssize_t>(s.size.height);
+                    return STATUS_OK;
+                }
+
                 if (pCocoaWindow == nil)
                     return STATUS_BAD_STATE;
 
@@ -1057,11 +1113,33 @@ namespace lsp
 
             ssize_t CocoaWindow::left()
             {
+                if (pCocoaParentView != nil)
+                {
+                    NSWindow *hostWnd = [pCocoaParentView window];
+                    if (hostWnd != nil)
+                    {
+                        NSRect b = [pCocoaParentView convertRect:[pCocoaParentView bounds] toView:nil];
+                        NSRect s = [hostWnd convertRectToScreen:b];
+                        return static_cast<ssize_t>(s.origin.x);
+                    }
+                }
                 return sSize.nLeft;
             }
 
             ssize_t CocoaWindow::top()
             {
+                if (pCocoaParentView != nil)
+                {
+                    NSWindow *hostWnd = [pCocoaParentView window];
+                    if (hostWnd != nil)
+                    {
+                        NSRect b = [pCocoaParentView convertRect:[pCocoaParentView bounds] toView:nil];
+                        NSRect s = [hostWnd convertRectToScreen:b];
+                        ssize_t screenH = 0, screenW = 0;
+                        pCocoaDisplay->screen_size(0, &screenW, &screenH);
+                        return static_cast<ssize_t>(screenH - s.origin.y - s.size.height);
+                    }
+                }
                 return sSize.nTop;
             }
 

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -311,17 +311,9 @@ namespace lsp
                     [windowObserverTokens removeAllObjects];
                 }
 
-                if (pCocoaView != nil)
+                if ([pCocoaView superview])
                 {
-                    // Stop the redraw timer and clear the display back-pointer
-                    // synchronously here so no tick can race with display tear-
-                    // down, instead of waiting for the view's -dealloc (which
-                    // may be deferred by the host's autorelease pool).
-                    [pCocoaView stopRedrawLoop];
-                    [pCocoaView setDisplay:NULL];
-
-                    if ([pCocoaView superview])
-                        [pCocoaView removeFromSuperview];
+                    [pCocoaView removeFromSuperview];
                     [pCocoaView release];
                     pCocoaView = NULL;
                 }
@@ -1002,8 +994,6 @@ namespace lsp
 
                         drop_surface();
                         pSurface = create_surface(pCocoaDisplay, pCocoaView, sSize.nWidth, sSize.nHeight);
-
-                        [pCocoaView startRedrawLoop];
                         break;
                     }
 
@@ -1012,7 +1002,6 @@ namespace lsp
                         bVisible = false;
                         //if (bWrapper) break;
 
-                        [pCocoaView stopRedrawLoop];
                         drop_surface();
                         break;
                     }

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -956,8 +956,29 @@ namespace lsp
             }
 
             void *CocoaWindow::handle()
-            {   
+            {
                 return (__bridge void*)pCocoaView;
+            }
+
+            status_t CocoaWindow::grab_events(grab_t group)
+            {
+                if (pCocoaDisplay == NULL)
+                    return STATUS_BAD_STATE;
+                return pCocoaDisplay->grab_events(this, group);
+            }
+
+            status_t CocoaWindow::ungrab_events()
+            {
+                if (pCocoaDisplay == NULL)
+                    return STATUS_BAD_STATE;
+                return pCocoaDisplay->ungrab_events(this);
+            }
+
+            bool CocoaWindow::is_grabbing_events() const
+            {
+                if (pCocoaDisplay == NULL)
+                    return false;
+                return pCocoaDisplay->is_grabbing_events(this);
             }
 
             //TODO: we need to map all events, and handle create_surface

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -311,9 +311,17 @@ namespace lsp
                     [windowObserverTokens removeAllObjects];
                 }
 
-                if ([pCocoaView superview])
+                if (pCocoaView != nil)
                 {
-                    [pCocoaView removeFromSuperview];
+                    // Stop the redraw timer and clear the display back-pointer
+                    // synchronously here so no tick can race with display tear-
+                    // down, instead of waiting for the view's -dealloc (which
+                    // may be deferred by the host's autorelease pool).
+                    [pCocoaView stopRedrawLoop];
+                    [pCocoaView setDisplay:NULL];
+
+                    if ([pCocoaView superview])
+                        [pCocoaView removeFromSuperview];
                     [pCocoaView release];
                     pCocoaView = NULL;
                 }


### PR DESCRIPTION
## Summary

Makes the Cocoa backend usable for VST3 plugins hosted inside a DAW on macOS. With the current `devel`, an LSP plug-in loaded in Ableton Live 12 (and almost certainly any other VST3 host) shows a blank window, ignores mouse input, and pops dropdowns at the wrong screen location. The four commits below address those issues; each is independently buildable and self-contained, so reviewing/merging piecewise is fine.

Tested on:

- macOS 15.7.1 (Sequoia, arm64) + Ableton Live 12.4.2 — VST3
- macOS 15.7.7 (Sequoia, Intel x86_64) + Ableton Live 11.0.12 — VST3
- Compressor, EQ, Limiter, Multiband, Dynamics, Impulse Responses, Filter dropdowns, Save/Load preset popups, knob drags that travel far outside the plug-in's view bounds.

Linux is untouched: every change is inside `src/main/cocoa/` / `include/private/cocoa/` and is guarded by `#ifdef PLATFORM_MACOSX`.

## Repro before the fix

1. `gmake config FEATURES="vst3 ui" && gmake && gmake install` on macOS 15.x.
2. Load `LSP Compressor Stereo` (or any other LSP VST3) in Ableton.
3. Plug-in window opens — completely blank. No widgets, no background, no response to clicks.

## Commits

### 1. `fix(cocoa): make CocoaCairoView layer-backed and first-responder`

On macOS 15 (Sequoia) AppKit will only call `-drawRect:` on NSViews that are layer-backed. `CocoaCairoView` never called `-setWantsLayer:YES`, so the view stayed blank after the first cairo render notification.

The view also did not advertise `acceptsFirstResponder` / `acceptsFirstMouse:`, so mouse and keyboard events were dropped when the host window was not key (which is the normal case in a DAW — focus is on the document window, not the plug-in's content view).

Defaulting the CALayer background to black avoids a one-frame white flash on first paint, most visible on popup menus.

### 2. `fix(cocoa): drive display main_iteration from view redraw timer`

`CocoaDisplay::do_main_iteration` is what dispatches `UIE_REDRAW`, which is what makes the widget tree render to the cairo surface, which in turn posts the `ForceExpose` notification that the view observes to flip `_needsRedrawing` to `true`. Without it, the 60 Hz NSTimer in `CocoaCairoView::triggerRedraw` never sees `_needsRedrawing == true` and never schedules a redraw.

In standalone apps that loop is driven by `IDisplay::main()`. In hosted mode the runloop hook is registered through `IRunLoop`, but the entire `register_run_loop()` body in the VST3 wrapper is wrapped in `#ifdef VST_USE_RUNLOOP_IFACE` — which is Linux-only. On macOS nothing was driving `do_main_iteration()`, so the UI simply never rendered.

Ticking it from the view's existing 60 Hz timer is the smallest change that gets the chain moving without touching the plugin framework.

### 3. `feat(cocoa): reparent view into host NSView when running in VST3 hosted mode`

The VST3 wrapper calls `UIWrapper::attached(parent, kPlatformTypeNSView)` to hand the plug-in the host's parent NSView slot. The wrapper then calls `wWindow->native()->set_parent(parent)` — but `CocoaWindow` did not override `set_parent`, so the call was a no-op. The plug-in's view was always anchored in its own standalone NSWindow, and the wrapper init path even did `[[pCocoaWindow contentView] addSubview:wrapperView ...]`, which is the *host's* document content view, so when wrapper mode was hit the view was added on top of Ableton's chrome.

Changes:

- New private member `pCocoaParentView` remembers the host's NSView (set both from the constructor and from `set_parent`).
- `set_parent` is implemented: on a non-null parent, hide the standalone NSWindow, move `pCocoaView` under the host view with full autoresizing, and promote it to first responder. On a null parent, restore the standalone NSWindow's contentView so the popup-window path still works.
- `show()` skips `makeKeyAndOrderFront:` when we have been reparented — otherwise an empty titled NSWindow appears next to the embedded UI.
- `left()` / `top()` / `get_absolute_geometry()` report screen coordinates of the host NSView when parented. `PopupWindow` and `arrange_rectangle()` rely on these to place dropdowns relative to the widget; without this they snap to the `(0, 0)` of the hidden standalone window.
- Default the standalone NSWindow background to black for the same reason as in commit 1.

### 4. `fix(cocoa): route mouse events to embedded view and capture drag target`

Two related bugs surface only when the window is embedded:

1. `[nsevent window]` is the host's NSWindow, so `CocoaDisplay::handle_event()`'s `find_window(nsWindow)` returned null and every event was dropped. Fall back to walking up the hit-test view's responder chain until we find a known `pCocoaView`.
2. Mid-drag the cursor frequently leaves the embedded view (especially knob drags that travel vertically). Once outside, the next `mouseDragged` / `mouseUp` also failed the lookup and the widget stayed "grabbed" — the user had to click somewhere else to release it. Cache the window that received `mouseDown` in `pDragTarget` and route all mouse events to it until the matching `mouseUp` clears it.

Event coordinates are now computed against `target->pCocoaView` directly (and translated across windows when needed) instead of hit-testing the host content view, which produced garbage offsets once the cursor left any known view.

`pDragTarget` and `lastMouseButton` are now explicitly initialised in the constructor.

## After the fix

- Plug-in renders fully inside the host's plug-in window slot.
- No extra floating standalone NSWindow.
- Knob drags continue smoothly when the cursor leaves the view and release on `mouseUp` regardless of cursor location.
- Filter / preset / file-browser dropdowns and popup menus open at the correct screen position relative to their owner widget.

## What this PR does *not* address

- `lsp-dsp-lib` AVX2 / AVX-512 inline asm (`0x40 + (%%rsp)` style GCC-AT&T syntax) does not assemble under Apple's clang IAS on Intel macOS. Worked around downstream by stubbing those translation units; an actual asm-template fix belongs in `lsp-dsp-lib`.
- The fontconfig / cairo / freetype dependency situation on macOS (Homebrew, `/opt/homebrew` vs `/usr/local`) is unchanged.

## Checklist

- [x] Linux build untouched (all changes inside `#ifdef PLATFORM_MACOSX`).
- [x] No public API changes (only added macOS-side `override`s for already-virtual `IWindow` methods).