### PR TITLE
Cocoa: fix VST3 embedded window geometry (resize/scaling, popup placement)

### DIFF
--- a/include/private/cocoa/CocoaCairoView.h
+++ b/include/private/cocoa/CocoaCairoView.h
@@ -34,6 +34,7 @@
 @interface CocoaCairoView : NSView
 
     @property (assign) cairo_surface_t *imageSurface;
+    @property (assign) CGImageRef lastImage;    // Last rendered frame, redrawn when no fresh surface is available (live resize)
     @property (strong) NSCursor *nextCursor;
     @property (assign) bool needsRedrawing;
     @property (nonatomic, assign) lsp::ws::cocoa::CocoaDisplay *display;

--- a/include/private/cocoa/CocoaWindow.h
+++ b/include/private/cocoa/CocoaWindow.h
@@ -57,8 +57,9 @@ namespace lsp
                     CocoaCairoView      *pCocoaView;                    // The View of the window
                     NSCursor            *pCocoaCursor;                  // The Cursor of the View
                     NSWindow            *transientParent;
-                    NSMutableArray      *windowObserverTokens; 
-                    NSMutableArray      *viewObserverTokens; 
+                    NSMutableArray      *windowObserverTokens;
+                    NSMutableArray      *viewObserverTokens;
+                    id                   pParentFrameToken;              // Frame-change observer on the host slot view (bWrapper)
                 
                 protected:
                     typedef struct btn_event_t

--- a/src/main/cocoa/CocoaCairoView.mm
+++ b/src/main/cocoa/CocoaCairoView.mm
@@ -63,11 +63,27 @@
 
         CGContextRestoreGState(context);
 
-        CGImageRelease(image);
+        // Keep the frame: during a live host resize AppKit redraws the view on
+        // every frame change, usually before the widget framework has produced
+        // a surface for the new size — without a cached frame the view flashes
+        // its background (black) until the next redraw tick.
+        if (self->_lastImage != NULL)
+            CGImageRelease(self->_lastImage);
+        self->_lastImage = image;
 
         cairo_surface_destroy(self->_imageSurface);
         self->_imageSurface = NULL;
-    } 
+    }
+    else if (self->_lastImage != NULL)
+    {
+        // No fresh frame yet — stretch the previous one over the current bounds
+        CGContextRef context = [[NSGraphicsContext currentContext] CGContext];
+        CGContextSaveGState(context);
+        CGContextTranslateCTM(context, 0, self.bounds.size.height);
+        CGContextScaleCTM(context, 1, -1);
+        CGContextDrawImage(context, CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height), self->_lastImage);
+        CGContextRestoreGState(context);
+    }
     
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center postNotificationName:@"RedrawRequest"
@@ -145,6 +161,12 @@
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    if (self->_lastImage != NULL)
+    {
+        CGImageRelease(self->_lastImage);
+        self->_lastImage = NULL;
+    }
 
     if (self.trackingArea)
     {

--- a/src/main/cocoa/CocoaDisplay.mm
+++ b/src/main/cocoa/CocoaDisplay.mm
@@ -137,11 +137,16 @@ namespace lsp
                 if (!standaloneApp)
                 {
                     LSPDisplayTimerProxy *proxy = [[LSPDisplayTimerProxy alloc] initWithDisplay:this];
-                    NSTimer *timer = [NSTimer scheduledTimerWithTimeInterval:(1.0/60.0)
+                    NSTimer *timer = [NSTimer timerWithTimeInterval:(1.0/60.0)
                                               target:proxy
                                               selector:@selector(tick:)
                                               userInfo:nil
                                               repeats:YES];
+                    // NSRunLoopCommonModes, not the default mode: during a live window
+                    // resize (or menu tracking) the run loop switches to an event
+                    // tracking mode where default-mode timers do not fire — the UI
+                    // would stop redrawing for the whole duration of the drag.
+                    [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
                     pIterationTimer      = (void *) timer;   // owned by run loop
                     pIterationTimerProxy = (void *) proxy;   // owned by us
                 }

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -109,7 +109,10 @@ namespace lsp
                 {
                     ssize_t screenWidth, screenHeight;
                     pCocoaDisplay->screen_size(0, &screenWidth, &screenHeight);
-                    NSRect frame = NSMakeRect(sSize.nLeft, screenHeight - sSize.nTop - sSize.nHeight + pCocoaDisplay->get_window_title_height(), sSize.nWidth, sSize.nHeight + pCocoaDisplay->get_window_title_height());    
+                    // Content rect only — initWithContentRect derives the frame from
+                    // the style mask. Inflating the height by the title height here
+                    // made the content taller than requested by exactly the title bar.
+                    NSRect frame = NSMakeRect(sSize.nLeft, screenHeight - sSize.nTop - sSize.nHeight, sSize.nWidth, sSize.nHeight);
 
                     // Create a window
                     NSWindow *window = [[NSWindow alloc]
@@ -874,7 +877,13 @@ namespace lsp
                 ssize_t screenWidth, screenHeight;
                 pCocoaDisplay->screen_size(0, &screenWidth, &screenHeight);
 
-                NSRect contentRect = NSMakeRect(sSize.nLeft, screenHeight - sSize.nTop - sSize.nHeight + pCocoaDisplay->get_window_title_height(), sSize.nWidth, sSize.nHeight);
+                // sSize positions the CONTENT (client area) in top-origin screen
+                // coordinates; frameRectForContentRect adds whatever chrome the window
+                // style actually has. Do NOT add the display's global title-height
+                // fudge here: for borderless windows (menus, combo popups) there is no
+                // chrome to compensate, and the fudge made every popup appear one
+                // title-bar height ABOVE the requested point.
+                NSRect contentRect = NSMakeRect(sSize.nLeft, screenHeight - sSize.nTop - sSize.nHeight, sSize.nWidth, sSize.nHeight);
                 NSRect frameRect = [window frameRectForContentRect:contentRect];
 
                 [window setFrame:frameRect display:YES animate:NO];
@@ -1053,8 +1062,12 @@ namespace lsp
                 ssize_t screenWidth, screenHeight;
                 pCocoaDisplay->screen_size(0, &screenWidth, &screenHeight);
 
+                // Content occupies the bottom part of the frame (title chrome, if
+                // any, sits above it), so the content's top-origin Y is simply
+                // screenH - (frame bottom + content height). Mirrors set_geometry(),
+                // which positions the content rect without a title-height fudge.
                 realize->nLeft   = static_cast<ssize_t>(frame.origin.x);
-                realize->nTop    = static_cast<ssize_t>(screenHeight - frame.origin.y - cFrame.size.height + pCocoaDisplay->get_window_title_height() /*frame.origin.y*/);
+                realize->nTop    = static_cast<ssize_t>(screenHeight - frame.origin.y - cFrame.size.height);
                 realize->nWidth  = static_cast<ssize_t>(cFrame.size.width);
                 realize->nHeight = static_cast<ssize_t>(cFrame.size.height);
 

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -89,6 +89,7 @@ namespace lsp
 
                 windowObserverTokens = [[NSMutableArray alloc] init];
                 viewObserverTokens = [[NSMutableArray alloc] init];
+                pParentFrameToken = nil;
             }
 
             CocoaWindow::~CocoaWindow()
@@ -292,6 +293,13 @@ namespace lsp
 
             void CocoaWindow::destroy()
             {
+                if (pParentFrameToken != nil)
+                {
+                    [[NSNotificationCenter defaultCenter] removeObserver:pParentFrameToken];
+                    [pParentFrameToken release];
+                    pParentFrameToken = nil;
+                }
+
                 if (bWrapper)
                 {
                     for (id token in viewObserverTokens)
@@ -378,6 +386,14 @@ namespace lsp
                 if (pCocoaView == nil)
                     return STATUS_BAD_STATE;
 
+                // Drop the frame observer of the previous host slot view (if any)
+                if (pParentFrameToken != nil)
+                {
+                    [[NSNotificationCenter defaultCenter] removeObserver:pParentFrameToken];
+                    [pParentFrameToken release];
+                    pParentFrameToken = nil;
+                }
+
                 if (hostView != nil)
                 {
                     if (pCocoaWindow != nil)
@@ -394,6 +410,31 @@ namespace lsp
                         [pCocoaView release];
                     }
                     pCocoaParentView = hostView;
+
+                    // Follow host-driven resizes of the slot view. Some hosts (REAPER)
+                    // resize the parent NSView directly during a live window drag in
+                    // addition to / instead of calling IPlugView::onSize, so a frame
+                    // observer is the only reliable signal. set_geometry() is a no-op
+                    // when the size did not change, so this can not loop.
+                    [hostView setPostsFrameChangedNotifications:YES];
+                    id token = [[NSNotificationCenter defaultCenter]
+                                    addObserverForName:NSViewFrameDidChangeNotification
+                                    object:hostView
+                                    queue:[NSOperationQueue mainQueue]
+                                    usingBlock:^(NSNotification *note) {
+                                        NSView *slot = (NSView *)note.object;
+                                        NSRect b = [slot bounds];
+                                        lsp_trace("host slot frame changed -> %dx%d", int(b.size.width), int(b.size.height));
+                                        if ((b.size.width < 2.0) || (b.size.height < 2.0))
+                                            return;
+                                        rectangle_t r;
+                                        r.nLeft   = sSize.nLeft;
+                                        r.nTop    = sSize.nTop;
+                                        r.nWidth  = b.size.width;
+                                        r.nHeight = b.size.height;
+                                        set_geometry(&r);
+                                    }];
+                    pParentFrameToken = [token retain];
                 }
                 else if (pCocoaParentView != nil)
                 {
@@ -705,10 +746,18 @@ namespace lsp
         
             status_t CocoaWindow::update_window_hints()
             {
+                // Embedded mode: [pCocoaView window] is the HOST's window. Setting
+                // contentMin/MaxSize on it fights the host's own layout (its window
+                // content = our view + host chrome, so clamping the content to our
+                // view size ratchets the window by exactly the chrome size on every
+                // resize round-trip — observed in REAPER as +392x+284 per step).
+                if ((bWrapper) || (pCocoaParentView != nil))
+                    return STATUS_OK;
+
                 NSWindow * const window = [pCocoaView window];
                 if (window == NULL)
                     return STATUS_BAD_STATE;
-                
+
                 ws::size_limit_t c;
                 status_t res = get_actual_size_constraints(&c);
                 if (res != STATUS_OK)
@@ -755,12 +804,9 @@ namespace lsp
 
             status_t CocoaWindow::set_geometry(const rectangle_t *realize)
             {
-                if (!pCocoaWindow)
+                if (pCocoaView == nil)
                     return STATUS_BAD_STATE;
-                NSWindow * const  window = [pCocoaView window];
-                if (!window)
-                    return STATUS_BAD_STATE;
-                
+
                 rectangle_t old = sSize;
 
                 sSize.nLeft = realize->nLeft;
@@ -773,25 +819,72 @@ namespace lsp
                     (old.nWidth == sSize.nWidth) &&
                     (old.nHeight == sSize.nHeight))
                     return STATUS_OK;
-                
-                // Calculate the frame rect from the content rect
+
                 lsp_trace("Resize / move window {left=%d, top=%d, width=%d, height=%d}\n", int(sSize.nLeft), int(sSize.nTop), int(sSize.nWidth), int(sSize.nHeight));
 
-                // TODO: handle case when window is resized in wrapper mode with some menu added from DAW
+                // Embedded == our view lives in a host-owned NSView slot. NOTE: in VST3
+                // hosted mode the window is created via create_window() (bWrapper is
+                // false!) and only becomes embedded when IPlugView::attached() calls
+                // set_parent() — so the discriminator is pCocoaParentView, not bWrapper.
+                if ((bWrapper) || (pCocoaParentView != nil))
+                {
+                    // Embedded in a host-owned NSView. The outer NSWindow belongs to the
+                    // host, so we must NOT resize it from here. In hosted VST3 mode the
+                    // host owns the outer geometry and drives it through
+                    // IPlugView::onSize (host-initiated, e.g. an FX-window frame drag)
+                    // and IPlugFrame::resizeView (plug-in-initiated, e.g. MENU->Scaling).
+                    // Resizing [pCocoaView window] (== the host window) here produces a
+                    // host<->plug-in resize ping-pong, observed in REAPER as
+                    // 951x551 -> 944x548 -> 951x551. Only size our own embedded view and
+                    // its backing surface, then let the widget framework re-layout.
+                    lsp_trace("set_geometry(embedded): %dx%d -> %dx%d (surface=%p)",
+                        int(old.nWidth), int(old.nHeight), int(sSize.nWidth), int(sSize.nHeight), pSurface);
+                    NSRect vf = [pCocoaView frame];
+                    [pCocoaView updateFrame:NSMakeRect(vf.origin.x, vf.origin.y, sSize.nWidth, sSize.nHeight)];
+
+                    if (pSurface != nullptr)
+                        pSurface->resize(sSize.nWidth, sSize.nHeight);
+
+                    // Tell the widget framework about the new size so it re-lays-out its
+                    // widgets. handle_event() forwards UIE_RESIZE to the tk handler even
+                    // in wrapper mode (the `if (bWrapper) break;` there only skips the
+                    // native surface bookkeeping we already did just above). This drives
+                    // the host-initiated (onSize) path; for the plug-in-initiated path
+                    // tk already holds this size, so the re-entrant set_geometry() it
+                    // triggers returns early at the old==new check above and no ping-pong
+                    // can build up.
+                    event_t ue;
+                    init_event(&ue);
+                    ue.nType   = UIE_RESIZE;
+                    ue.nLeft   = 0;
+                    ue.nTop    = 0;
+                    ue.nWidth  = sSize.nWidth;
+                    ue.nHeight = sSize.nHeight;
+                    handle_event(&ue);
+
+                    invalidate();
+                    return STATUS_OK;
+                }
+
+                // Standalone: we own the NSWindow, so drive the real window geometry.
+                NSWindow * const window = [pCocoaView window];
+                if (!window)
+                    return STATUS_BAD_STATE;
+
                 ssize_t screenWidth, screenHeight;
                 pCocoaDisplay->screen_size(0, &screenWidth, &screenHeight);
 
                 NSRect contentRect = NSMakeRect(sSize.nLeft, screenHeight - sSize.nTop - sSize.nHeight + pCocoaDisplay->get_window_title_height(), sSize.nWidth, sSize.nHeight);
-                NSRect frameRect = [[pCocoaView window] frameRectForContentRect:contentRect];
-            
-                [[pCocoaView window] setFrame:frameRect display:YES animate:NO];
-                NSRect newContentBounds = [[pCocoaView window] contentView].bounds;
+                NSRect frameRect = [window frameRectForContentRect:contentRect];
+
+                [window setFrame:frameRect display:YES animate:NO];
+                NSRect newContentBounds = [window contentView].bounds;
                 [pCocoaView updateFrame:newContentBounds];
 
                 status_t res = update_window_hints();
                 if (res != STATUS_OK)
                     return res;
-                
+
                 if (pSurface != nullptr)
                 {
                     pSurface->resize(sSize.nWidth, sSize.nHeight);
@@ -818,16 +911,6 @@ namespace lsp
                 transientParent = nil;
                 commit_border_style(enBorderStyle, nActions);
 
-                if (bWrapper && pCocoaView && pCocoaWindow) {
-                    NSRect contentRect = [[pCocoaWindow contentView] bounds];
-                    [pCocoaView updateFrame:contentRect];
-
-                    [pCocoaView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-                    if (pSurface != nullptr) {
-                        pSurface->resize(contentRect.size.width, contentRect.size.height);
-                    } 
-                } 
-                
                 if (!has_parent())
                 {
                     if (over != nullptr)
@@ -851,7 +934,32 @@ namespace lsp
                 init_event(&ue);
                 ue.nType       = UIE_SHOW;
                 handle_event(&ue);
-                
+
+                // Embedded mode: assert OUR size to the host. The window is fixed-size
+                // (canResize() is false on macOS): its size is the widget layout at the
+                // current UI scaling, so at open the host must be brought to it — not
+                // the other way around. Emitting UIE_RESIZE with the current size makes
+                // the tk window fire SLOT_RESIZE, which the VST3 wrapper turns into
+                // IPlugFrame::resizeView(); the host then resizes its slot and the
+                // frame observer installed in set_parent() confirms the geometry. This
+                // also purges any stale FX-window size the host remembered from a
+                // previous session. Must happen AFTER UIE_SHOW: only then is the tk
+                // window mapped and processing UIE_RESIZE.
+                if (((bWrapper) || (pCocoaParentView != nil)) &&
+                    (sSize.nWidth >= 2) && (sSize.nHeight >= 2))
+                {
+                    lsp_trace("show: asserting size %dx%d to the host",
+                        int(sSize.nWidth), int(sSize.nHeight));
+                    event_t re;
+                    init_event(&re);
+                    re.nType   = UIE_RESIZE;
+                    re.nLeft   = 0;
+                    re.nTop    = 0;
+                    re.nWidth  = sSize.nWidth;
+                    re.nHeight = sSize.nHeight;
+                    handle_event(&re);
+                }
+
                 // Invalidate window contents for redraw
                 invalidate();
 
@@ -923,10 +1031,16 @@ namespace lsp
                     NSRect s = [hostWnd convertRectToScreen:b];
                     ssize_t screenW = 0, screenH = 0;
                     pCocoaDisplay->screen_size(0, &screenW, &screenH);
+                    // Origin comes from the host slot view, but the SIZE is our logical
+                    // size (sSize). The slot lags behind: when tk resizes (e.g.
+                    // MENU->Scaling), slot_ui_resize in the VST3 wrapper reads this
+                    // rectangle and passes it to IPlugFrame::resizeView — reporting the
+                    // slot size here would ask the host for the size it already has,
+                    // so the FX window would never follow tk resizes.
                     realize->nLeft   = static_cast<ssize_t>(s.origin.x);
                     realize->nTop    = static_cast<ssize_t>(screenH - s.origin.y - s.size.height);
-                    realize->nWidth  = static_cast<ssize_t>(s.size.width);
-                    realize->nHeight = static_cast<ssize_t>(s.size.height);
+                    realize->nWidth  = sSize.nWidth;
+                    realize->nHeight = sSize.nHeight;
                     return STATUS_OK;
                 }
 
@@ -1020,7 +1134,10 @@ namespace lsp
                     case UIE_RESIZE:
                     {
                         lsp_trace("Resize event: {l=%d, t=%d, w=%d, h=%d}", int(ev->nLeft), int(ev->nTop), int(ev->nWidth), int(ev->nHeight));
-                        if (bWrapper) break;
+                        // Embedded: set_geometry() already did the native bookkeeping
+                        // (view frame, surface) before emitting this event; only the
+                        // tk handler below needs to see it.
+                        if ((bWrapper) || (pCocoaParentView != nil)) break;
 
                         sSize.nLeft = ev->nLeft;
                         sSize.nTop = ev->nTop;

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -435,6 +435,21 @@ namespace lsp
                                         r.nTop    = sSize.nTop;
                                         r.nWidth  = b.size.width;
                                         r.nHeight = b.size.height;
+                                        // Some hosts (REAPER) shrink the slot below the
+                                        // widget layout's minimum without consulting
+                                        // checkSizeConstraint. Clamp to the constraints
+                                        // the toolkit registered via set_size_constraints
+                                        // so widgets keep their minimum layout; the host
+                                        // window then simply clips the view, like any
+                                        // fixed-minimum plug-in.
+                                        if (sConstraints.nMinWidth > 0)
+                                            r.nWidth  = lsp_max(r.nWidth,  sConstraints.nMinWidth);
+                                        if (sConstraints.nMinHeight > 0)
+                                            r.nHeight = lsp_max(r.nHeight, sConstraints.nMinHeight);
+                                        if (sConstraints.nMaxWidth > 0)
+                                            r.nWidth  = lsp_min(r.nWidth,  sConstraints.nMaxWidth);
+                                        if (sConstraints.nMaxHeight > 0)
+                                            r.nHeight = lsp_min(r.nHeight, sConstraints.nMaxHeight);
                                         set_geometry(&r);
                                     }];
                     pParentFrameToken = [token retain];

--- a/src/main/cocoa/CocoaWindow.mm
+++ b/src/main/cocoa/CocoaWindow.mm
@@ -944,30 +944,11 @@ namespace lsp
                 ue.nType       = UIE_SHOW;
                 handle_event(&ue);
 
-                // Embedded mode: assert OUR size to the host. The window is fixed-size
-                // (canResize() is false on macOS): its size is the widget layout at the
-                // current UI scaling, so at open the host must be brought to it — not
-                // the other way around. Emitting UIE_RESIZE with the current size makes
-                // the tk window fire SLOT_RESIZE, which the VST3 wrapper turns into
-                // IPlugFrame::resizeView(); the host then resizes its slot and the
-                // frame observer installed in set_parent() confirms the geometry. This
-                // also purges any stale FX-window size the host remembered from a
-                // previous session. Must happen AFTER UIE_SHOW: only then is the tk
-                // window mapped and processing UIE_RESIZE.
-                if (((bWrapper) || (pCocoaParentView != nil)) &&
-                    (sSize.nWidth >= 2) && (sSize.nHeight >= 2))
-                {
-                    lsp_trace("show: asserting size %dx%d to the host",
-                        int(sSize.nWidth), int(sSize.nHeight));
-                    event_t re;
-                    init_event(&re);
-                    re.nType   = UIE_RESIZE;
-                    re.nLeft   = 0;
-                    re.nTop    = 0;
-                    re.nWidth  = sSize.nWidth;
-                    re.nHeight = sSize.nHeight;
-                    handle_event(&re);
-                }
+                // Embedded mode needs no size handshake here: the host prepares the
+                // wrapping window from getSize() before attaching, host-initiated
+                // resizes arrive via IPlugView::onSize() -> set_geometry(), and the
+                // slot-view frame observer installed in set_parent() catches hosts
+                // that resize the slot without calling onSize().
 
                 // Invalidate window contents for redraw
                 invalidate();


### PR DESCRIPTION
Follow-up to #6, addressing review remarks (3) window sizing and (4) popups appearing shifted up. Four commits, macOS-only (`PLATFORM_MACOSX`), Linux/Windows untouched.

## 1. Stop driving host window geometry in VST3 embedded mode

Key finding: in VST3 hosted mode the plug-in window is created via `create_window()`, so `bWrapper` is `false`. The window becomes embedded later, when `IPlugView::attached()` reparents the view via `set_parent()`. Embedded behaviour now keys on `pCocoaParentView != nil`. With that in place, four problems are fixed (all of them wrote to the HOST's NSWindow, because `[pCocoaView window]` is the host FX window after reparenting):

- `set_geometry()` resized the host window directly. This was the source of the `951x551 <-> 944x548` ping-pong from the #6 discussion. Embedded mode now sizes only our subview and the cairo surface, then emits `UIE_RESIZE` so the widget framework re-lays-out.
- `update_window_hints()` set `contentMin/MaxSize` on the host window. The host window content is our view plus host chrome, so clamping it to the view size grew the FX window by exactly the chrome size (+392x+284 in REAPER) on every resize round-trip.
- `get_absolute_geometry()` reported the stale host slot size, so `SLOT_RESIZE -> IPlugFrame::resizeView()` asked the host for the size it already had, and `MENU -> Scaling` never moved the FX window.
- A `NSViewFrameDidChangeNotification` observer on the slot view follows host resizes. REAPER resizes the slot during a live border drag without calling `onSize()` or `checkSizeConstraint()` (verified with tracing), so the observer is the only reliable signal. It clamps adopted sizes to the constraints from `set_size_constraints()`: below the layout minimum the view keeps its minimum and the host window just clips it.

## 2. Drop the title-height fudge from geometry conversions (popups shifted up)

Your remark (4): popups appeared one title-bar height above the requested point. `set_geometry()` added the display's global title height to the Y flip, but borderless windows (menus, combo dropdowns) have no chrome for `frameRectForContentRect:` to compensate. `sSize` addresses the CONTENT rect, so the conversion is now a plain `screenH - nTop - nHeight` in `set_geometry()`, `get_absolute_geometry()` and `init()`, where the height was also inflated by the title height (visible as a clipped bottom status line). This also resolves the "FX window position resets to (0,0)" item from my #6 notes.

## 3. Live resize (your remark about the black screen while dragging)

The 60 Hz redraw timer is now scheduled in `NSRunLoopCommonModes`. In the default mode the timer does not fire while the run loop is in the event-tracking mode of a live window drag, so the UI stopped redrawing for the whole drag. In addition, `CocoaCairoView` keeps the last rendered frame and draws it when AppKit repaints the view before the widget framework has produced a surface for the new size, which removes black flashes between resize steps. With these two changes VST3 live resize in REAPER re-lays-out and repaints continuously, same as CLAP.

## Verified

REAPER 7.75 + Ableton Live 12, arm64 macOS 15.7 (Sequoia): opens at layout size at the current scaling, live border drag re-lays-out smoothly in both directions, `MENU -> Scaling` converges in a single round-trip, popups land exactly at the expected position and close on outside click, FX open/close cycles clean.

Companion `lsp-plugin-fw` PR: content scale factor correction for HiDPI (see linked comment).